### PR TITLE
Time scale sync

### DIFF
--- a/VTOLVR-Multiplayer/Messages/MessageType.cs
+++ b/VTOLVR-Multiplayer/Messages/MessageType.cs
@@ -29,5 +29,6 @@ public enum MessageType
     FireCountermeasure, //This is when a player fires a countermeasure
     Death, //This is when a player dies
     HostLoaded, // This is when the host has loaded and the clients can load
-    WingFold //this is when a player folds or unfolds their wings
+    WingFold, //this is when a player folds or unfolds their wings
+    WorldData // This is timescale sync data
 }

--- a/VTOLVR-Multiplayer/Messages/Message_WorldData.cs
+++ b/VTOLVR-Multiplayer/Messages/Message_WorldData.cs
@@ -1,0 +1,14 @@
+﻿using System;
+[Serializable]
+public class Message_WorldData : Message
+{
+    public float timeScale;
+    public ulong UID;
+
+    public Message_WorldData(float timeScaleData, ulong uID)
+    {
+        this.timeScale = timeScaleData;
+        UID = uID;
+        type = MessageType.WorldData;
+    }
+}

--- a/VTOLVR-Multiplayer/Messages/Message_WorldData.cs
+++ b/VTOLVR-Multiplayer/Messages/Message_WorldData.cs
@@ -3,12 +3,11 @@
 public class Message_WorldData : Message
 {
     public float timeScale;
-    public ulong UID;
 
-    public Message_WorldData(float timeScaleData, ulong uID)
+
+    public Message_WorldData(float timeScaleData)
     {
         this.timeScale = timeScaleData;
-        UID = uID;
         type = MessageType.WorldData;
     }
 }

--- a/VTOLVR-Multiplayer/Networker.cs
+++ b/VTOLVR-Multiplayer/Networker.cs
@@ -491,7 +491,7 @@ public class Networker : MonoBehaviour
                         EngineTiltUpdate.Invoke(packet);
                     break;
                 case MessageType.WorldData:
-                    // Debug.Log("case engine tilt update");
+                    Debug.Log("case world data");
                     if (WorldDataUpdate != null)
                         WorldDataUpdate.Invoke(packet);
                     break;

--- a/VTOLVR-Multiplayer/Networker.cs
+++ b/VTOLVR-Multiplayer/Networker.cs
@@ -48,6 +48,7 @@ public class Networker : MonoBehaviour
     public static event UnityAction<Packet> Death;
     public static event UnityAction<Packet> WingFold;
     public static event UnityAction<Packet> MissileUpdate;
+    public static event UnityAction<Packet> WorldDataUpdate;
     public static event UnityAction<Packet> RequestNetworkUID;
     #endregion
     #region Host Forwarding Suppress By Message Type List
@@ -488,6 +489,11 @@ public class Networker : MonoBehaviour
                     // Debug.Log("case engine tilt update");
                     if (EngineTiltUpdate != null)
                         EngineTiltUpdate.Invoke(packet);
+                    break;
+                case MessageType.WorldData:
+                    // Debug.Log("case engine tilt update");
+                    if (WorldDataUpdate != null)
+                        WorldDataUpdate.Invoke(packet);
                     break;
                 case MessageType.Disconnecting:
                     Debug.Log("case disconnecting");

--- a/VTOLVR-Multiplayer/Networkers/WorldDataNetworker_Receiver.cs
+++ b/VTOLVR-Multiplayer/Networkers/WorldDataNetworker_Receiver.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using Steamworks;
+
+/// <summary>
+/// Updates objects with a  rigidbody over the network using velocity and position.
+/// </summary>
+public class WorldDataNetworker_Receiver : MonoBehaviour
+{
+    public ulong networkUID;
+
+    private void Awake()
+    {
+
+        Networker.WorldDataUpdate += WorldDataUpdate;
+
+    }
+
+    public void WorldDataUpdate(Packet packet)
+    {
+
+        Message_WorldData worldDataUpdate = (Message_WorldData)((PacketSingle)packet).message;
+
+
+        Time.timeScale = worldDataUpdate.timeScale;
+
+    }
+
+    public void OnDisconnect(Packet packet)
+    {
+        Message_Disconnecting message = ((PacketSingle)packet).message as Message_Disconnecting;
+        Destroy(gameObject);
+    }
+
+    public void OnDestroy()
+    {
+        Networker.WorldDataUpdate -= WorldDataUpdate;
+        Networker.Disconnecting -= OnDisconnect;
+        Debug.Log("Destroyed WorldData Update");
+    }
+}

--- a/VTOLVR-Multiplayer/Networkers/WorldDataNetworker_Receiver.cs
+++ b/VTOLVR-Multiplayer/Networkers/WorldDataNetworker_Receiver.cs
@@ -11,7 +11,7 @@ using Steamworks;
 /// </summary>
 public class WorldDataNetworker_Receiver : MonoBehaviour
 {
-    public ulong networkUID;
+    private float serverTimescale = 1f;
 
     private void Awake()
     {
@@ -20,13 +20,25 @@ public class WorldDataNetworker_Receiver : MonoBehaviour
 
     }
 
+    // If this sucks (it probably does) find a better solution (I.E. Harmony Patch SteamVR Pausing) :sick:
+    public void Update()
+    {
+        // If the client's time scale is different than the servers timescale, force the clients to match
+        if (Time.timeScale != serverTimescale)
+        {
+            Debug.Log($"Client timescale { Time.timeScale } mismatch with server { serverTimescale } - Forcing client update");
+            Time.timeScale = serverTimescale;
+        }
+    }
+
     public void WorldDataUpdate(Packet packet)
     {
 
         Message_WorldData worldDataUpdate = (Message_WorldData)((PacketSingle)packet).message;
-
-
         Time.timeScale = worldDataUpdate.timeScale;
+        serverTimescale = worldDataUpdate.timeScale;
+
+        Debug.Log($"Set the timescale {worldDataUpdate.timeScale}");
 
     }
 

--- a/VTOLVR-Multiplayer/Networkers/WorldDataNetworker_Sender.cs
+++ b/VTOLVR-Multiplayer/Networkers/WorldDataNetworker_Sender.cs
@@ -7,14 +7,14 @@ using UnityEngine;
 
 class WorldDataNetworker_Sender : MonoBehaviour
 {
-    public ulong networkUID;
+
     private Message_WorldData lastMessage;
     float lastTimeScale;
 
     private void Awake()
     {
         lastTimeScale = Time.timeScale;
-        lastMessage = new Message_WorldData(lastTimeScale, networkUID);
+        lastMessage = new Message_WorldData(lastTimeScale);
     }
 
     void LateUpdate() {
@@ -22,14 +22,30 @@ class WorldDataNetworker_Sender : MonoBehaviour
         float curTimeScale = Time.timeScale;
 
         if (curTimeScale != lastTimeScale) {
-            lastMessage.UID = networkUID;
             lastMessage.timeScale = curTimeScale;
             if (Networker.isHost)
             {
+                Debug.Log($"Sending the timescale {lastMessage.timeScale}");
                 Networker.SendGlobalP2P(lastMessage, Steamworks.EP2PSend.k_EP2PSendReliable);
             }
             
             lastTimeScale = curTimeScale;
         }
     }
+
+    public void OnDisconnect(Packet packet)
+    {
+        // If the player disconnects force the timescale back to 1 other wise they get stuck.
+
+        lastMessage.timeScale = 1f;
+        if (Networker.isHost)
+        {
+            Debug.Log($"Host Disconnecting - Setting timescale to {lastMessage.timeScale}");
+            Networker.SendGlobalP2P(lastMessage, Steamworks.EP2PSend.k_EP2PSendReliable);
+        }
+
+        Message_Disconnecting message = ((PacketSingle)packet).message as Message_Disconnecting;
+        Destroy(gameObject);
+    }
+
 }

--- a/VTOLVR-Multiplayer/Networkers/WorldDataNetworker_Sender.cs
+++ b/VTOLVR-Multiplayer/Networkers/WorldDataNetworker_Sender.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+class WorldDataNetworker_Sender : MonoBehaviour
+{
+    public ulong networkUID;
+    private Message_WorldData lastMessage;
+    float lastTimeScale;
+
+    private void Awake()
+    {
+        lastTimeScale = Time.timeScale;
+        lastMessage = new Message_WorldData(lastTimeScale, networkUID);
+    }
+
+    void LateUpdate() {
+
+        float curTimeScale = Time.timeScale;
+
+        if (curTimeScale != lastTimeScale) {
+            lastMessage.UID = networkUID;
+            lastMessage.timeScale = curTimeScale;
+            if (Networker.isHost)
+            {
+                Networker.SendGlobalP2P(lastMessage, Steamworks.EP2PSend.k_EP2PSendReliable);
+            }
+            
+            lastTimeScale = curTimeScale;
+        }
+    }
+}

--- a/VTOLVR-Multiplayer/PlayerManager.cs
+++ b/VTOLVR-Multiplayer/PlayerManager.cs
@@ -8,6 +8,7 @@ using Steamworks;
 using Harmony;
 using System.Collections;
 using System.Reflection;
+using UnityEngine.SceneManagement;
 
 public static class PlayerManager
 {
@@ -26,10 +27,15 @@ public static class PlayerManager
     private static GameObject av42cPrefab, fa26bPrefab, f45Prefab;
     private static List<ulong> spawnedVehicles = new List<ulong>();
     public static ulong localUID;
+
+    public static VTScenario currentScenario;
+    public static GameObject worldData;
+
     public struct Player
     {
         public CSteamID cSteamID;
         public GameObject vehicle;
+        
         public VTOLVehicles vehicleName;
         public ulong vehicleUID;
 
@@ -80,11 +86,35 @@ public static class PlayerManager
             if (spawnRequestQueue.Count != 0)
                 SpawnRequestQueue();
             Networker.alreadyInGame = true;
+
+
+
         }
 
         while (playersToSpawnQueue.Count > 0) {
             SpawnVehicle(playersToSpawnQueue.Dequeue(), playersToSpawnIdQueue.Dequeue());
         }
+
+        
+        if (!Networker.isHost)
+        {
+            // If the player is not the host, they only need a receiver?
+
+            worldData = new GameObject();
+            WorldDataNetworker_Receiver WorldDataNetworker = worldData.AddComponent<WorldDataNetworker_Receiver>();
+            WorldDataNetworker.networkUID = Networker.GenerateNetworkUID();
+        }
+        else
+        {
+            // If the player is the host, setup the sender so they can send world data
+
+            worldData = new GameObject();
+            WorldDataNetworker_Sender WorldDataNetworker = worldData.AddComponent<WorldDataNetworker_Sender>();
+            WorldDataNetworker.networkUID = Networker.GenerateNetworkUID();
+
+        }
+        
+
     }
 
     /// <summary>

--- a/VTOLVR-Multiplayer/PlayerManager.cs
+++ b/VTOLVR-Multiplayer/PlayerManager.cs
@@ -99,21 +99,17 @@ public static class PlayerManager
         if (!Networker.isHost)
         {
             // If the player is not the host, they only need a receiver?
-
+            Debug.Log($"Player not the host, adding world data receiver");
             worldData = new GameObject();
             WorldDataNetworker_Receiver WorldDataNetworker = worldData.AddComponent<WorldDataNetworker_Receiver>();
-            WorldDataNetworker.networkUID = Networker.GenerateNetworkUID();
         }
         else
         {
             // If the player is the host, setup the sender so they can send world data
-
+            Debug.Log($"Player is the host, setting up the world data sender");
             worldData = new GameObject();
             WorldDataNetworker_Sender WorldDataNetworker = worldData.AddComponent<WorldDataNetworker_Sender>();
-            WorldDataNetworker.networkUID = Networker.GenerateNetworkUID();
-
         }
-        
 
     }
 


### PR DESCRIPTION
Adds WorldData receiver and sender. Currently WorldData only contains the timescale information. 

Timescale gets sent when the host pauses (or changes timescale, mods?). Clients are forced to this timescale, if they pause, the game still runs.